### PR TITLE
fix invalid trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.9"
 keywords = ["one", "two"]
 license = {file = "LICENSE"}
 classifiers = [
-    "Intended Audience :: Data Scientists",
+    "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Changed Intended Audience to "Science/Research" as "Data Scientists" is not in the list https://github.com/pypa/trove-classifiers/blob/main/src/trove_classifiers/__init__.py